### PR TITLE
fix : navbar github link

### DIFF
--- a/components/NavBar.tsx
+++ b/components/NavBar.tsx
@@ -36,7 +36,7 @@ export const socials = [
         icon: <SiLinkedin size={18} />,
     },
     {
-        link: 'https://github.com/Innovation-Labs-PES',
+        link: 'https://github.com/PES-Innovation-Lab',
         name: 'GitHub',
         icon: <SiGithub size={18} />,
     },


### PR DESCRIPTION
fix for the navbar's GitHub link redirecting to the wrong page