### PR TITLE
fix: 2021 heads visibility

### DIFF
--- a/app/(main)/members/page.tsx
+++ b/app/(main)/members/page.tsx
@@ -65,21 +65,24 @@ function Members() {
     const [isDataLoaded, setDataLoaded] = useState<boolean>(false)
 
     useEffect(() => {
-        if (mOrH === 'Members'){
-            if (currentYear === 2021)
-                setCurrentYear(2022)
+        if (mOrH === 'Members') {
+            if (currentYear === 2021) setCurrentYear(2022)
             setYears([
                 2025, 2024, 2023, 2022, 2020, 2019, 2018, 2017, 2016, 2015,
             ])
-        }
-        else {
-            setYears([2025, 2024, 2023, 2022, 2021, 2020, 2019, 2018, 2017, 2016, 2015])
+        } else {
+            setYears([
+                2025, 2024, 2023, 2022, 2021, 2020, 2019, 2018, 2017, 2016,
+                2015,
+            ])
         }
         setDataLoaded(false)
         setCards([])
         const fetch = () => {
-            const membersOutput = (membersData as YearData)[currentYear.toString()] ?
-                (membersData as YearData)[currentYear.toString()].members
+            const membersOutput = (membersData as YearData)[
+                currentYear.toString()
+            ]
+                ? (membersData as YearData)[currentYear.toString()].members
                 : []
             const headsOutput = (headsData as HeadsData)[currentYear.toString()]
                 ? (headsData as HeadsData)[currentYear.toString()].heads

--- a/app/(main)/members/page.tsx
+++ b/app/(main)/members/page.tsx
@@ -36,9 +36,10 @@ const shuffleArray = <T,>(array: T[]): T[] => {
 }
 
 function Members() {
-    const years: number[] = [
+    const [years, setYears] = useState([
         2025, 2024, 2023, 2022, 2020, 2019, 2018, 2017, 2016, 2015,
-    ]
+    ])
+
     const [currentYear, setCurrentYear] = useState<number>(
         years.sort((a, b) => b - a)[0]
     )
@@ -64,12 +65,22 @@ function Members() {
     const [isDataLoaded, setDataLoaded] = useState<boolean>(false)
 
     useEffect(() => {
+        if (mOrH === 'Members'){
+            if (currentYear === 2021)
+                setCurrentYear(2022)
+            setYears([
+                2025, 2024, 2023, 2022, 2020, 2019, 2018, 2017, 2016, 2015,
+            ])
+        }
+        else {
+            setYears([2025, 2024, 2023, 2022, 2021, 2020, 2019, 2018, 2017, 2016, 2015])
+        }
         setDataLoaded(false)
         setCards([])
         const fetch = () => {
-            const membersOutput = (membersData as YearData)[
-                currentYear.toString()
-            ].members
+            const membersOutput = (membersData as YearData)[currentYear.toString()] ?
+                (membersData as YearData)[currentYear.toString()].members
+                : []
             const headsOutput = (headsData as HeadsData)[currentYear.toString()]
                 ? (headsData as HeadsData)[currentYear.toString()].heads
                 : []


### PR DESCRIPTION
Currently, heads from 2021 are not viewable on the website, since the members card does not have 2021 as an option.

Fixed this by changing years to include 2021, if the heads page is selected.

<img width="2506" height="836" alt="image" src="https://github.com/user-attachments/assets/b97c2e46-628a-482a-9f2b-133e623880ce" />


<img width="2488" height="885" alt="image" src="https://github.com/user-attachments/assets/ff18de74-a638-4602-879c-8e3dc6183db0" />
